### PR TITLE
ci: change to Bun.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-          cache: "npm"
-      - name: Install packages
-        run: |
-          npm ci
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Lint
-        run: |
-          npm run lint
+        run: bun run lint


### PR DESCRIPTION
Close: https://github.com/digital-go-jp/design-system-example-components/issues/14

Bun installation is so fast.  
Bun has upward compatible with node.js,
so I think It would be good to replace it.

I can estimate that it will be **5x** to **25x** faster.
https://github.com/oven-sh/bun/tree/main/bench/install