### PR TITLE
ci: set paths which don't need ci at paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches-ignore:
       - main
+    paths-ignore:
+      - '.github/**'
+      - '.vscode/**'
+      - 'README.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   deploy:


### PR DESCRIPTION
Close: https://github.com/digital-go-jp/design-system-example-components/issues/16
".vscode", ".github", etc.. は、ciを行う必要が有りません。

### 事例
https://github.com/honojs/hono/blob/main/.github/workflows/ci.yml