### PR TITLE
Update 1.4.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: バグレポート
+description: バグの詳細について記載してください。
+title: "バグの概要"
+labels: [bug]
+assignees: "-"
+body:
+  - type: checkboxes
+    attributes:
+      label: 事前確認
+      options:
+        - label: Issuesに同一の機能リクエストがないか確認しましたか
+          required: true
+  - type: textarea
+    id: overview
+    attributes:
+      label: バグ概要
+      description: 再現手順、バグの概要、期待される結果を記載してください。（必要に応じて画像を添付してください。）
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: バグが再現したOS
+      multiple: true
+      options:
+        - Windows
+        - macOS
+        - Android
+        - iOS
+        - Linux
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: バグが再現したブラウザ
+      multiple: true
+      options:
+        - Chrome
+        - Safari
+        - Firefox
+        - Microsoft Edge
+        - Opera
+  - type: input
+    id: version
+    attributes:
+      label: サンプルコンポーネントのバージョン
+      placeholder: "e.g., v1.4.2 or v2.0.0"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: 機能リクエスト
+description: 新機能リクエストもしくは既存機能の更新リクエストについて記載してください。
+title: "機能リクエストの概要"
+labels: [feature]
+assignees: []
+body:
+  - type: checkboxes
+    attributes:
+      label: 事前確認
+      options:
+        - label: Issuesに同一の機能リクエストがないか確認しましたか
+          required: true
+  - type: textarea
+    id: request
+    attributes:
+      label: リクエスト内容
+      description: リクエストの詳細を記載してください。（スクリーンショット、デモ等を合わせてご提供ください。）
+    validations:
+      required: true

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
           hidden
           flex-none
           peer-checked:inline-block
-          peer-checked:fill-sea-800
+          peer-checked:fill-blue-900
           peer-focus-visible:rounded-[4px]
           peer-focus-visible:outline
           peer-focus-visible:outline-2
@@ -41,14 +41,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
         className={`
           my-[2px]
           flex-none
-          ${isError ? 'fill-sun-800' : 'fill-sumi-900'}
+          ${isError ? 'fill-error-1' : 'fill-solid-grey-900'}
           peer-checked:hidden
           peer-focus-visible:rounded-[4px]
           peer-focus-visible:outline
           peer-focus-visible:outline-2
           peer-focus-visible:-outline-offset-1
           peer-focus-visible:outline-focus-yellow
-          peer-disabled:fill-sumi-500
+          peer-disabled:fill-solid-grey-420
         `}
         fill='none'
         height='24'
@@ -65,7 +65,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
         className={`
           text-std-16N-7
           ${isError ? 'text-error-1' : 'text-solid-grey-900'}
-          peer-disabled:text-solid-grey-600
+          peer-disabled:text-solid-grey-420
         `}
       >
         {children}

--- a/src/components/input/Input.stories.tsx
+++ b/src/components/input/Input.stories.tsx
@@ -17,9 +17,7 @@ export const Example: Story = {
     return (
       <div className='flex flex-col gap-8'>
         <div className='flex flex-col gap-2'>
-          <Label htmlFor='test'>
-            ラベル<RequirementBadge isOptional={true}>任意</RequirementBadge>
-          </Label>
+          <Label htmlFor='test'>ラベル</Label>
           <SupportText id='test-support-text'>サポートテキスト</SupportText>
           <Input aria-describedby='test-support-text' id='test' />
         </div>
@@ -48,7 +46,7 @@ export const Example: Story = {
             id='test-error'
             isError={true}
             required
-            value=''
+            defaultValue=''
           />
           <ErrorText aria-live='polite' id='test-error-text' role='alert'>
             ＊エラーテキスト

--- a/src/components/legend/Legend.tsx
+++ b/src/components/legend/Legend.tsx
@@ -10,8 +10,8 @@ export const Legend = (props: LegendProps) => {
   return (
     <legend
       className={`
-        flex w-fit items-center gap-2 text-dns-16B-2 text-solid-grey-900
-        ${isDisabled ? 'text-solid-grey-600' : ''}
+        flex w-fit items-center gap-2 text-dns-16B-2
+        ${isDisabled ? 'text-solid-grey-420' : 'text-solid-grey-900'}
         ${className ?? ''}
       `}
       {...rest}

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -29,11 +29,11 @@ export const PaginationItem = (props: PaginationItemProps) => {
 };
 
 export const PaginationFirst = (props: PaginationItemProps) => {
-  const { className, ...rest } = props;
+  const { className, 'aria-label': ariaLabel, ...rest } = props;
   return (
     <a className={`${paginationItemStyle} ${className}`} {...rest}>
       <svg
-        aria-label={rest['aria-label'] ?? '最初のページに移動する'}
+        aria-label={ariaLabel ?? '最初のページに移動する'}
         fill='none'
         height='24'
         role='img'
@@ -53,11 +53,11 @@ export const PaginationFirst = (props: PaginationItemProps) => {
 };
 
 export const PaginationPrev = (props: PaginationItemProps) => {
-  const { className, ...rest } = props;
+  const { className, 'aria-label': ariaLabel, ...rest } = props;
   return (
     <a className={`${paginationItemStyle} ${className}`} {...rest}>
       <svg
-        aria-label={rest['aria-label'] ?? '前のページへ戻る'}
+        aria-label={ariaLabel ?? '前のページへ戻る'}
         fill='none'
         height='24'
         role='img'
@@ -71,11 +71,11 @@ export const PaginationPrev = (props: PaginationItemProps) => {
 };
 
 export const PaginationLast = (props: PaginationItemProps) => {
-  const { className, ...rest } = props;
+  const { className, 'aria-label': ariaLabel, ...rest } = props;
   return (
     <a className={`${paginationItemStyle} ${className}`} {...rest}>
       <svg
-        aria-label={rest['aria-label'] ?? '最後のページに移動する'}
+        aria-label={ariaLabel ?? '最後のページに移動する'}
         className='-scale-x-100'
         fill='none'
         height='24'
@@ -99,11 +99,11 @@ export const PaginationLast = (props: PaginationItemProps) => {
 };
 
 export const PaginationNext = (props: PaginationItemProps) => {
-  const { className, ...rest } = props;
+  const { className, 'aria-label': ariaLabel, ...rest } = props;
   return (
     <a className={`${paginationItemStyle} ${className}`} {...rest}>
       <svg
-        aria-label={rest['aria-label'] ?? '次のページへ進む'}
+        aria-label={ariaLabel ?? '次のページへ進む'}
         fill='none'
         height='24'
         role='img'

--- a/src/components/radio/Radio.tsx
+++ b/src/components/radio/Radio.tsx
@@ -16,7 +16,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
         className={`
           my-[2px] hidden flex-none
           peer-checked:inline-block
-          peer-checked:fill-sea-800
+          peer-checked:fill-blue-900
           peer-focus-visible:rounded-8
           peer-focus-visible:outline
           peer-focus-visible:outline-2
@@ -38,14 +38,14 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
         aria-hidden={true}
         className={`
           my-[2px] flex-none
-          ${isError ? 'fill-sun-800' : 'fill-sumi-900'}
+          ${isError ? 'fill-error-1' : 'fill-solid-grey-900'}
           peer-checked:hidden
           peer-focus-visible:rounded-8
           peer-focus-visible:outline
           peer-focus-visible:outline-2
           peer-focus-visible:-outline-offset-1
           peer-focus-visible:outline-focus-yellow
-          peer-disabled:fill-sumi-500
+          peer-disabled:fill-solid-grey-420
         `}
         fill='none'
         height='24'
@@ -62,7 +62,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
         className={`
           text-std-16N-7
           ${isError ? 'text-error-1' : 'text-solid-grey-900'}
-          peer-disabled:text-solid-grey-600
+          peer-disabled:text-solid-grey-420
         `}
       >
         {children}

--- a/src/components/scrollToTopButton/ScrollToTopButton.stories.tsx
+++ b/src/components/scrollToTopButton/ScrollToTopButton.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 import { ScrollToTopButton } from './ScrollToTopButton';
 
 const meta = {
@@ -12,6 +13,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Example: Story = {
   args: {
-    href: '#',
+    onClick: fn(),
   },
 };

--- a/src/components/scrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/scrollToTopButton/ScrollToTopButton.tsx
@@ -7,15 +7,15 @@ export const scrollToTopButtonStyle = `
   active:border-blue-1200 active:bg-blue-300 active:text-blue-1200
 `;
 
-export type ScrollToTopButtonProps = ComponentProps<'a'>;
+export type ScrollToTopButtonProps = ComponentProps<'button'>;
 
 export const ScrollToTopButton = (props: ScrollToTopButtonProps) => {
-  const { className, ...rest } = props;
+  const { className, 'aria-label': ariaLabel, ...rest } = props;
 
   return (
-    <a className={`${scrollToTopButtonStyle} ${className ?? ''}`} {...rest}>
+    <button type='button' className={`${scrollToTopButtonStyle} ${className ?? ''}`} {...rest}>
       <svg
-        aria-label={rest['aria-label'] ?? 'ページ上部に戻る'}
+        aria-label={ariaLabel ?? 'ページの先頭へ戻る'}
         fill='none'
         height='16'
         role='img'
@@ -27,6 +27,6 @@ export const ScrollToTopButton = (props: ScrollToTopButtonProps) => {
           fill='currentColor'
         />
       </svg>
-    </a>
+    </button>
   );
 };

--- a/src/components/select/Select.stories.tsx
+++ b/src/components/select/Select.stories.tsx
@@ -17,9 +17,7 @@ export const Example: Story = {
     return (
       <div className='flex flex-col gap-8'>
         <div className='flex flex-col gap-2'>
-          <Label htmlFor='test'>
-            ラベル<RequirementBadge isOptional={true}>任意</RequirementBadge>
-          </Label>
+          <Label htmlFor='test'>ラベル</Label>
           <SupportText id='test-support-text'>サポートテキスト</SupportText>
           <Select aria-describedby='test-support-text' id='test'>
             <option hidden value=''>

--- a/src/components/textarea/Textarea.stories.tsx
+++ b/src/components/textarea/Textarea.stories.tsx
@@ -24,9 +24,7 @@ export const Example: Story = {
     return (
       <div className='flex flex-col gap-8'>
         <div className='flex flex-col gap-2'>
-          <Label htmlFor='test'>
-            ラベル<RequirementBadge isOptional={true}>任意</RequirementBadge>
-          </Label>
+          <Label htmlFor='test'>ラベル</Label>
           <SupportText id='test-support-text'>サポートテキスト</SupportText>
           <Textarea aria-describedby='test-support-text' id='test' />
         </div>
@@ -45,10 +43,7 @@ export const Example: Story = {
         </div>
 
         <div className='flex flex-col gap-2'>
-          <Label htmlFor='test-rows'>
-            rows 属性を使用したテキストエリア
-            <RequirementBadge isOptional={true}>任意</RequirementBadge>
-          </Label>
+          <Label htmlFor='test-rows'>rows 属性を使用したテキストエリア</Label>
           <SupportText id='test-rows-support-text'>
             rows 属性の値に 2 を設定したテキストエリアの例
           </SupportText>
@@ -63,6 +58,7 @@ export const Example: Story = {
           <Textarea
             aria-describedby='test-error-text'
             aria-invalid={true}
+            defaultValue=''
             id='test-error'
             isError={true}
             required
@@ -74,7 +70,7 @@ export const Example: Story = {
 
         <div className='flex flex-col gap-2'>
           <Label htmlFor='test-filled-error'>
-            ラベル<RequirementBadge isOptional={true}>任意</RequirementBadge>
+            ラベル<RequirementBadge>※必須</RequirementBadge>
           </Label>
           <SupportText id='test-filled-error-support-text'>サポートテキスト</SupportText>
           <Textarea

--- a/src/components/tiledRadio/TiledRadio.tsx
+++ b/src/components/tiledRadio/TiledRadio.tsx
@@ -12,14 +12,14 @@ export const TiledRadioItem = (props: TiledRadioItemProps) => {
   return (
     <span className='flex flex-1 flex-col'>
       <span
-        className={`text-std-16N-7 text-solid-grey-900 ${isDisabled ? 'text-solid-grey-600' : ''}`}
+        className={`text-std-16N-7 ${isDisabled ? 'text-solid-grey-420' : 'text-solid-grey-900'}`}
       >
         {props.title}
       </span>
       {props.description && (
         <span
-          className={`text-[0.75rem] leading-1-7 text-solid-grey-600 ${
-            isDisabled ? '!text-solid-grey-600' : ''
+          className={`text-[0.75rem] leading-1-7 ${
+            isDisabled ? 'text-solid-grey-420' : 'text-solid-grey-600'
           }`}
         >
           {props.description}
@@ -61,7 +61,7 @@ export const TiledRadio = forwardRef<HTMLInputElement, TiledRadioProps>((props, 
         className={`
           hidden
           peer-checked:inline-block
-          peer-checked:fill-sea-800
+          peer-checked:fill-blue-900
         `}
         fill='none'
         height='24'
@@ -77,9 +77,9 @@ export const TiledRadio = forwardRef<HTMLInputElement, TiledRadioProps>((props, 
       <svg
         aria-hidden={true}
         className={`
-          ${isError ? 'fill-error-1' : 'fill-sumi-900'}
+          ${isError ? 'fill-error-1' : 'fill-solid-grey-900'}
           peer-checked:hidden
-          peer-disabled:fill-sumi-500
+          peer-disabled:fill-solid-grey-420
         `}
         height='24'
         viewBox='0 0 24 24'


### PR DESCRIPTION
## 更新内容

### Issue 対応分

- InputコンポーネントStorybookの、テキスト入力欄が空、かつエラー状態のサンプルで、テキストが入力できない問題を修正（ #19 ）
- TextareaコンポーネントStorybookの、任意項目、かつエラー状態のサンプルを必須項目に変更（ #19 ）
- Legend コンポーネントの `isDisabled` のカラースタイルが適用されていなかった問題を修正（ #20 ）
- ScrollToTopButtonコンポーネントのルートの要素を `a` から `button` 要素を使うように変更。また、デフォルトの `aria-label` を「ページの先頭へ戻る」に変更（ #21 ）

### その他の更新

- Issueテンプレートを追加
- Input, Select, TextareaコンポーネントのStorybookのサンプルから、「任意」ラベルを削除
- `disabled` 状態のカラーが `solid-grey-600` になっていたものを v1.4.2 デザインデータに合わせ `solid-grey-420` に変更
- 旧カラーが指定されていたものをカラー2.0に修正
- アイコンボタン系のコンポーネントでカスタムの aria-label を指定した際に、ルートの要素と `svg` 要素に重複して同じ aria-label が付与されていた問題を修正