### PR TITLE
feat(storybook): DrawerのDocsを表示

### DIFF
--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
+  tags: ['autodocs'],
 } satisfies Meta;
 
 export default meta;


### PR DESCRIPTION
Drawerのストーリーに`tags: [autodocs]`を追加し、StorybookでDocsタブが表示されるように修正しました。